### PR TITLE
Make TestDataMaker extend from Loggable and replaced println by logger

### DIFF
--- a/music-gradebook/build.sbt
+++ b/music-gradebook/build.sbt
@@ -1,13 +1,14 @@
-name := "Lift 2.5 starter template"
+name := "Music Grade-Book"
 
 version := "0.0.1"
 
-organization := "net.liftweb"
+organization := "com.dbschools"
 
 scalaVersion := "2.9.1"
 
 resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositories/snapshots",
-                "releases"        at "http://oss.sonatype.org/content/repositories/releases"
+                "releases"        at "http://oss.sonatype.org/content/repositories/releases",
+                "Java.net Maven2 Repository"     at "http://download.java.net/maven/2/"
                 )
 
 seq(com.github.siasia.WebPlugin.webSettings :_*)

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/TestDataMaker.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/TestDataMaker.scala
@@ -3,8 +3,9 @@ package com.dbschools.mgb
 import math.random
 import org.squeryl.PrimitiveTypeMode._
 import schema.{MusicianGroup, Musician, AppSchema}
+import net.liftweb.common.Loggable
 
-object TestDataMaker {
+object TestDataMaker extends Loggable {
 
   def getNames(names: String): Array[String] = names.split("\\W").map(_.capitalize)
 
@@ -218,18 +219,6 @@ cindy""")
       createAndGroupStudents()
     }
   }
-  
-  /** Feed database with dummy data.
-   * 
-   * @note pre-condition: DB needs to be initialized
-   * @see com.dbschools.mgb.Db#initialize()
-   */
-  def feedDbWithDummyData() {
-    deleteStudents()
-    // @todo investigate why a java.lang.ArrayIndexOutOfBoundsException is reached when creating groupIds: case _ => GroupIds(1)
-    // todo avoid duplication between this method and main
-    // createAndGroupStudents()
-  }
 
   private def deleteStudents() {
     AppSchema.musicianGroups  .deleteWhere(mg => mg.id === mg.id)
@@ -239,7 +228,7 @@ cindy""")
   }
 
   private def createAndGroupStudents() {
-    val instrumentIds = AppSchema.instruments.map(_.instrument_id).toArray
+    val instrumentIds = AppSchema.instruments.map(_.idField.get).toArray
     var id = 10000 // Until we set up sequences
     lastNames.foreach(lastName => {
       val firstName = firstNames((random * firstNames.length).toInt)
@@ -257,7 +246,7 @@ cindy""")
           instrumentIds((random * instrumentIds.length).toInt), 2013))
         id += 1
       })
-      println("Added %s, %s to %d groups".format(lastName, firstName, groupIds.size))
+      logger.trace("Added %s, %s to %d groups".format(lastName, firstName, groupIds.size))
     })
   }
 
@@ -267,8 +256,10 @@ cindy""")
     /** Returns the requested number of unique, randomly-chosen group IDs */
     def apply(num: Int) = {
       var ids = Set[Int]()
-      while(ids.size < num)
-        ids += groupIds((random * groupIds.length).toInt)
+      if(!groupIds.isEmpty){
+        while(ids.size < num)
+          ids += groupIds((random * groupIds.length).toInt)
+        }
       ids
     }
   }

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/model/GroupAssignments.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/model/GroupAssignments.scala
@@ -27,7 +27,7 @@ object GroupAssignments extends Loggable {
 
   private def conditions(opId: Option[Int], m: Musician, mg: MusicianGroup, g: Group, i: Instrument) = {
     val joinConditions = m.musician_id === mg.musician_id and mg.group_id === g.group_id and
-      mg.instrument_id === i.instrument_id
+      mg.instrument_id === i.idField.get
     opId.map(id => joinConditions and m.musician_id === id) | joinConditions
   }
 

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/schema/Instrument.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/schema/Instrument.scala
@@ -1,6 +1,26 @@
 package com.dbschools.mgb.schema
 
-case class Instrument(
-  instrument_id:  Int,
-  name:           String
-)
+import org.squeryl.annotations.Column
+
+import net.liftweb.record.MetaRecord
+import net.liftweb.record.Record
+import net.liftweb.record.field.IntField
+import net.liftweb.record.field.StringField
+import net.liftweb.squerylrecord.KeyedRecord
+
+/** Instruments (Violin, Cello, Trumpet, etc.)
+ * 
+ * @since 1.0.0
+ */
+case class Instrument private() extends Record[Instrument] with KeyedRecord[Int]{
+  override def meta = Instrument
+  
+  /** Instrument's identifier */
+  @Column("instrument_id")
+  override val idField = new IntField(this)
+  
+  /** Instrument's name (i.e.: Viola, Trombone, etc.) */
+  val name = new StringField(this, "")
+}
+
+object Instrument extends Instrument with MetaRecord[Instrument]

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/schema/SchemaHelper.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/schema/SchemaHelper.scala
@@ -5,6 +5,7 @@ import net.liftweb.common.Loggable
 import net.liftweb.squerylrecord.RecordTypeMode.transaction
 import net.liftweb.squerylrecord.SquerylRecord
 import com.dbschools.mgb.TestDataMaker
+import java.sql.SQLException
 
 /**
  * Initializes a DB connection and setup the connection pool.
@@ -33,12 +34,11 @@ object SchemaHelper extends Loggable {
         AppSchema.printDdl
         AppSchema.drop
         AppSchema.create
-        TestDataMaker.feedDbWithDummyData()
       }
       catch {
-        case e: Exception ⇒ {
-          logger.error("Recreate schema has failed.")
-          throw new Exception("Failed to recreate the schema." + e.printStackTrace)
+        case exception: SQLException ⇒ {
+          logger.error("Recreate schema has failed.", exception)
+          throw new Exception("Failed to recreate the schema." + exception.getMessage)
         }
       }
     }

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/snippet/StudentDetails.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/snippet/StudentDetails.scala
@@ -37,7 +37,7 @@ class StudentDetails extends Loggable {
                   if (checked) selectedMusicianGroups += ga.musicianGroup.id -> ga.musicianGroup
                   else selectedMusicianGroups -= ga.musicianGroup.id
                   Noop
-                }) ++ Text("%d: %s, %s".format(ga.musicianGroup.school_year, ga.group.name, ga.instrument.name)))
+                }) ++ Text("%d: %s, %s".format(ga.musicianGroup.school_year, ga.group.name, ga.instrument.name.get)))
 
     def makeDetails(md: MusicianDetails) =
       ".heading *"      #> "%s, %d, %d, %d".format(md.musician.name, md.musician.student_id,
@@ -55,7 +55,7 @@ class StudentDetails extends Loggable {
     val groups = AppSchema.groups.toSeq
     var selectedGroupId = groups.headOption.map(_.group_id)
     val instruments = AppSchema.instruments.toSeq
-    var selectedInstrumentId = instruments.headOption.map(_.instrument_id)
+    var selectedInstrumentId = instruments.headOption.map(_.idField.get)
     var replaceExistingAssignment = true
 
     def process(): JsCmd = {
@@ -69,7 +69,7 @@ class StudentDetails extends Loggable {
                       Text("Replace the existing group assignment, if one exists, otherwise create an additional one")) &
     "#groups"      #> SHtml.ajaxSelect(groups.map(g => (g.group_id.toString, g.name)).toSeq, Empty, gid => {
                        selectedGroupId = Some(gid.toInt) }) &
-    "#instruments" #> (SHtml.ajaxSelect(AppSchema.instruments.map(i => (i.instrument_id.toString, i.name)).toSeq,
+    "#instruments" #> (SHtml.ajaxSelect(AppSchema.instruments.map(i => (i.idField.get.toString, i.name.get)).toSeq,
                        Empty, iid => {
                        selectedInstrumentId = Some(iid.toInt)}) ++ SHtml.hidden(process))
   }

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/snippet/Students.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/snippet/Students.scala
@@ -19,7 +19,7 @@ class Students {
       ".id       *" #> row.musician.musician_id &
       ".stuId    *" #> row.musician.student_id &
       ".group    *" #> row.group.name &
-      ".instr    *" #> row.instrument.name
+      ".instr    *" #> row.instrument.name.get
     )
 
   def inNoGroups = {


### PR DESCRIPTION
Make TestDataMaker extend from Loggable and replaced println by logger calls
Added a condition in TestDataMaker.GroupIds.apply in order to prevent an ArrayIndexOfBoundExcepion in case Group table is empty
Removed TestDataMaker.feedDbWithDummyData method
Refactored SchemaHelper.recreateSchema: removed call to TestDataMaker and scoped the try-catch to a SQLException instead of a generic Exception
Added a short scaladoc to Instrument case class
Refactored Instrument case class and "converted" to lift record. Also refactored TestDataMaker, Students, StudentDetails and GroupAssignment as a side effect.
Updated build.sbt: name, organization and resolver
