### PR TITLE
User test data

### DIFF
--- a/music-gradebook/src/main/resources/props/default.props
+++ b/music-gradebook/src/main/resources/props/default.props
@@ -1,5 +1,7 @@
 ## Properties for DEVELOPMENT mode
 
+db.development=true
+
 # DB Driver: h2, postgres
 db.engine=h2
 

--- a/music-gradebook/src/main/resources/props/production.default.props
+++ b/music-gradebook/src/main/resources/props/production.default.props
@@ -1,4 +1,6 @@
-## Properties for DEVELOPMENT mode
+## Properties for PRODUCTION mode
+
+db.development=false
 
 # DB Driver: h2, postgres
 db.engine=postgres
@@ -11,10 +13,3 @@ db.driver=org.postgresql.Driver
 db.url=jdbc:postgresql://localhost:5432/dbschools
 db.user=dbschools
 db.password=dbschools
-
-# Data for demo user
-data.users.demo.login=demo
-data.users.demo.epassword=$2a$10$rvyDSAv3D57BGJStAeviROTUSuqUij4t/kVC5oyKOCtZUIqoeuvwO
-# decrypted password= is "demo123"
-data.users.demo.name.first=Demo
-data.users.demo.name.last=Demo User

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/Db.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/Db.scala
@@ -28,6 +28,9 @@ object Db {
 
     if (Props.getBool("db.recreate", false)) {
       SchemaHelper.recreateSchema
+      if (Props.getBool("db.development", false)) {
+        TestDataMaker.createDefaultUserData
+      }
     } else {
       SchemaHelper.touch
     }

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/TestDataMaker.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/TestDataMaker.scala
@@ -5,6 +5,7 @@ import org.squeryl.PrimitiveTypeMode._
 import schema.{MusicianGroup, Musician, AppSchema, User}
 import net.liftweb.common.Loggable
 import net.liftweb.util.Props
+import java.sql.SQLException
 
 object TestDataMaker extends Loggable {
 
@@ -268,7 +269,17 @@ cindy""")
   /** Initializes the music_user table with a demo user.*/
   def createDefaultUserData() {
     def prop(name: String) = Props.get(name).get
-    AppSchema.users.insert(User(1, prop("data.users.demo.login"), "", prop("data.users.demo.epassword"), prop("data.users.demo.name.first"), prop("data.users.demo.name.last"), true))
-    logger.info("Added a demo user")
+    transaction {
+      try {
+        AppSchema.users.insert(User(1, prop("data.users.demo.login"), "", prop("data.users.demo.epassword"), prop("data.users.demo.name.first"), prop("data.users.demo.name.last"), true))
+        logger.info("Added a demo user")
+      }
+      catch {
+        case exception: SQLException ⇒ {
+          // Only warn about the problem. Failing to add a default user is not considered fatal.
+          logger.warn("Failed to add a test user.", exception)
+        }
+      }
+    }
   }
 }

--- a/music-gradebook/src/main/scala/com/dbschools/mgb/schema/SchemaHelper.scala
+++ b/music-gradebook/src/main/scala/com/dbschools/mgb/schema/SchemaHelper.scala
@@ -35,7 +35,6 @@ object SchemaHelper extends Loggable {
         AppSchema.printDdl
         AppSchema.drop
         AppSchema.create
-        TestDataMaker.createDefaultUserData()
       }
       catch {
         case exception: SQLException ⇒ {
@@ -44,8 +43,6 @@ object SchemaHelper extends Loggable {
         }
       }
     }
-    
-
   }
 
   /**


### PR DESCRIPTION
Added the possibility to feed the H2 DB with a dummy user, hence it's possible to use login the app with jetty+h2

This only work for development mode.

Default credentials:
login: demo
pass: demo123

It can be changed at props/default.props
