### PR TITLE
Added a gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+music-gradebook/console.devmode.log
+music-gradebook/project/project/
+music-gradebook/project/target/
+music-gradebook/target/


### PR DESCRIPTION
So that we don't accidentally commit files we do...n't need.
I could have made the rules more generic, but decided to start this way, specific paths, and if we find those folders in several of the subprojects, we can then change the rules in `.gitignore.`
