### PR TITLE
Let's all use the same sbt version

### DIFF
--- a/music-gradebook/project/build.properties
+++ b/music-gradebook/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.12.4


### PR DESCRIPTION
By specifying the sbt version, we avoid running into issues where some of us may be on older/newer version, and as we add plugins,
we either all run into issue sor we are all happy with a working
setup
